### PR TITLE
feat: RetroList 구현

### DIFF
--- a/src/components/RetroList.tsx
+++ b/src/components/RetroList.tsx
@@ -1,0 +1,82 @@
+import styled from '@emotion/styled'
+import React from 'react'
+import RetroListMock from '../mocks/RetroListMock'
+
+interface RetroListProps {
+    width?: string
+}
+
+const RetroList = () => {
+  return (
+    <RetroListWrapper>
+        <RetroListHeader>
+            <RetroListTitle>제목</RetroListTitle>
+            <RetroListTitle>기간</RetroListTitle>
+            <RetroListTitle>작성자</RetroListTitle>
+            <RetroListTitle>회고록 유형</RetroListTitle>
+        </RetroListHeader>
+        <RetroListContent>
+            {RetroListMock.response.retrospects.map((item) =>  (
+                <RetroListElement key={item.retro_id}>
+                    <RetroListItem>{item.sprint_name}</RetroListItem>
+                    <RetroListItem>{`${item.start_date} ~ ${item.end_date}`}</RetroListItem>
+                    <RetroListItem>{item.manager}</RetroListItem>
+                    <RetroListItem>{item.temp_name}</RetroListItem>
+                </RetroListElement>
+            ))}
+        </RetroListContent>
+    </RetroListWrapper>
+  )
+}
+
+const RetroListWrapper = styled.div<RetroListProps>`
+    border-radius: 0.8rem;
+    border: 0.1rem solid #D4D4DB;
+    display: flex;
+    flex-direction: column;
+    margin: 1rem;
+    width: ${({ width }) => width || '80rem'}
+`
+
+const RetroListHeader = styled.div`
+    display: flex;
+    flex-direction: row;
+    padding: 1rem;
+    border-bottom: 0.1rem solid #D4D4DB;
+`
+
+const RetroListTitle = styled.div`
+    display: flex;
+    text-align: center;
+    flex: 1;
+    justify-content: center;
+    align-items: center;
+    font-weight: 500;
+    color: #545669;
+    font-size: 1.15rem;
+`
+
+const RetroListContent = styled.div`
+
+`
+
+const RetroListElement = styled.div`
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.9rem;
+    color: #555555;
+    border-bottom: 0.1rem solid #D4D4DB;
+
+    &:last-child {
+        border-bottom: none;
+    }
+`
+
+const RetroListItem = styled.div<{ flexGrow?: number }>`
+    flex: 1;
+    text-align: center;
+`
+
+export default RetroList

--- a/src/mocks/RetroListMock.ts
+++ b/src/mocks/RetroListMock.ts
@@ -1,0 +1,30 @@
+const RetroListMock = {
+    success: true,
+    response: {
+        project_id: 1,
+          summary: "모든 회고록 내용 기반 요약한 내용",
+          retrospects: [
+              {
+                  retro_id: 1,
+                  sprint_id: 1,
+                  sprint_name: "스프린트 1",
+                  start_date: "2024.10.10.",
+                  end_date: "2024.10.13.",
+                  temp_name: "KPT(Keep-Problem-Try)",
+                  manager : "박경준"
+              },
+              {			
+                  retro_id: 2,
+                  sprint_id: 2,
+                  sprint_name: "스프린트 2",
+                  start_date: "2024.10.14.",
+                  end_date: "2024.10.17.",
+                  temp_name: "CSS(Continue-Stop-Start)",
+                  manager : "박경준"
+              }
+          ]
+    }, 
+    error: null
+  }
+  
+export default RetroListMock

--- a/src/pages/Yunn.tsx
+++ b/src/pages/Yunn.tsx
@@ -1,5 +1,9 @@
+import RetroList from "../components/RetroList";
+
 const Yunn = () => {
-  return <div>Yunn</div>;
+  return (
+    <RetroList />
+  )
 };
 
 export default Yunn;


### PR DESCRIPTION
<!--연관된 티켓 번호를 작성하세요. 예) #111-->
# 🎟️ Related Ticket: #10 

# ✏️ Description
- RetroList 컴포넌트를 피그마에 맞게 구현하였습니다.

# 🧩 How
- 해당 컴포넌트는 회고 리스트 페이지에서 사용됩니다.
- 달라지는 부분은 width입니다.
  - width 는 emotion-styled 속성을 살려 props로 전달받으며, default 값이 지정되어 있습니다.

# ⚠️ PR 참고 사항
- 통신 연결 전이므로 RetroListMock.ts 파일을 생성하여 예상 목업 데이터를 통해 회고 리스트 내용을 구현하였습니다.
  - 추후 api 연결시 통신 코드로 대체될 예정입니다.

# 📸 Screen Shot
<img width="1323" alt="image" src="https://github.com/user-attachments/assets/773691f0-fd15-442f-af00-3b782cd88672">

# ✅ Todo Check
- [x] RetroList 컴포넌트 구현

# 💬리뷰 요구사항
- @Klomachenko [api 문서](https://www.notion.so/API-9e25130ff53b445f86ed07bd245dea42?p=ecd3c1f00a5b48ddb6c455087c5b56d8&pm=s)를 보면 응답값의 변수명이 camelCase가 아닌 snake_case로 되어있던데 프론트에서 camelCase로 가공해서 써야할까요? 아니면 이대로 snake_case로 써도 괜찮을지, 백엔드에 camelCase로 변경 요청을 해야할지 여쭤봅니다..!

# Etc.

