### PR TITLE
feat: TaskCardInput 구현

### DIFF
--- a/src/components/DefaultButton.tsx
+++ b/src/components/DefaultButton.tsx
@@ -5,12 +5,13 @@ interface ButtonProps {
   width?: string;
   height?: string;
   text?: string;
+  fontSize?: string;
 }
 
 const MainButton = styled.button<ButtonProps>`
   width: ${({ width }) => width || '10.3125rem'};
   height: ${({ height }) => height || '3.125rem'};
-  font-size: 1.3125rem;
+  font-size: ${({ fontSize }) => fontSize || '1.3125rem'};
   background-color: #88afe3;
   cursor: pointer;
   color: white;
@@ -25,9 +26,14 @@ const MainButton = styled.button<ButtonProps>`
   }
 `;
 
-const DefaultButton: React.FC<ButtonProps> = ({ width, height, text }) => {
+const DefaultButton: React.FC<ButtonProps> = ({
+  width,
+  height,
+  text,
+  fontSize,
+}) => {
   return (
-    <MainButton width={width} height={height}>
+    <MainButton width={width} height={height} fontSize={fontSize}>
       {text}
     </MainButton>
   );

--- a/src/components/TaskCardInput.tsx
+++ b/src/components/TaskCardInput.tsx
@@ -1,0 +1,66 @@
+import styled from '@emotion/styled';
+import React from 'react';
+import DefaultButton from './DefaultButton';
+
+interface TaskCardInputProps {
+  width?: string;
+  height?: string;
+}
+
+const KanbanBox = styled.div<TaskCardInputProps>`
+  box-sizing: border-box;
+  width: ${({ width }) => width || '18.25rem'};
+  height: ${({ height }) => height || '6.625rem'};
+  background-color: white;
+  cursor: pointer;
+  color: #505050;
+  border: 0.1875rem solid #88afe3;
+  border-radius: 0.5rem;
+  padding: 0.625rem;
+  display: flex;
+  flex-direction: column;
+`;
+
+const ContentBox = styled.textarea`
+  box-sizing: border-box;
+  overflow-y: auto;
+  width: 100%;
+  height: 80%;
+  font-size: 1.25rem;
+  color: #505050;
+  display: flex;
+  border: none;
+  resize: none;
+  ::placeholder {
+    color: #c7c8cb;
+  }
+`;
+
+const NameBox = styled.div`
+  box-sizing: border-box;
+  width: 100%;
+  height: 20%;
+  font-size: 1rem;
+  color: #aeaaaa;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+`;
+
+const TaskCardInput: React.FC<TaskCardInputProps> = ({ width, height }) => {
+  return (
+    <KanbanBox width={width} height={height}>
+      <ContentBox placeholder='할 일을 입력하세요'></ContentBox>
+      <NameBox>
+        <DefaultButton
+          text='완료'
+          width='3.375rem'
+          height='1.5rem'
+          fontSize='1rem'
+        />
+      </NameBox>
+    </KanbanBox>
+  );
+};
+
+export default TaskCardInput;

--- a/src/pages/Klomachenko.tsx
+++ b/src/pages/Klomachenko.tsx
@@ -1,12 +1,9 @@
-import TaskCard from '../components/TaskCard';
+import TaskCardInput from '../components/TaskCardInput';
 
 const Klomachenko = () => {
   return (
     <div>
-      <TaskCard
-        taskContent='API를 상의 후에 설계합니다. API를 상의 후에 설계합니다.API를 상의 후에 설계합니다.API를 상의 후에 설계합니다.API를 상의 후에 설계합니다.API를 상의 후에 설계합니다.API를 상의 후에 설계합니다.API를 상의 후에 설계합니다.'
-        authorName='박경준'
-      />
+      <TaskCardInput width='20rem' height='10rem' />
     </div>
   );
 };


### PR DESCRIPTION
<!--연관된 티켓 번호를 작성하세요. 예) #111-->
# 🎟️ Related Ticket: #18 

# ✏️ Description
<!--설명을 작성하세요.-->
- TaskCardInput을 figma에 맞게 구현하였습니다.

# 🧩 How
<!-- 구현 방법을 작성하세요.-->
- 해당 Input은 KanBan Board를 사용하는 페이지 구간에서 사용됩니다.
- 달라지는 부분은 width, height 입니다.
  - width, height 는 emotion-styled 속성을 살려 props로 전달받습니다.
- 버튼은 기존 공통 컴포넌트은 DefaultButton을 사용하였습니다.
```tsx
const TaskCardInput: React.FC<TaskCardInputProps> = ({ width, height }) => {
  return (
    <KanbanBox width={width} height={height}>
      <ContentBox placeholder='할 일을 입력하세요'></ContentBox>
      <NameBox>
        <DefaultButton
          text='완료'
          width='3.375rem'
          height='1.5rem'
          fontSize='1rem'
        />
      </NameBox>
    </KanbanBox>
  );
};
```
- 컴포넌트 사용은 아래와 같습니다.
```tsx
<TaskCardInput width='20rem' height='10rem' />
```

# ⚠️ PR 참고 사항
<!-- 참고 사항을 작성하세요.-->
- 저번 pr과 동일하게 width, height 입력이 없을 시 지정된 default 값으로 조정됩니다.
- 해당 컴포넌트의 width를 글 작성 부분은 80% 버튼 부분은 20%를 주었는데, 차라리 버튼 부분을 fixed로 고정하는게 더 나을까 라는 생각도 듭니다.
  - 해당 컴포넌트가 현재 커지는 부분은 ui상에 보이지 않으나, 아직 와이어프레임이 완벽하지 않으니, 이 부분은 추후 해당 문제가 생기면 리팩터링 하도록 하겠습니다. 


# 📸 Screen Shot
<!-- 이미지를 첨부하세요.-->
![image](https://github.com/user-attachments/assets/b035fac1-bd6d-4e4f-9c70-0a7a2a96ffd6)

# ✅ Todo Check
<!--todo 진행 상황을 체크하세요.-->
- [x] TaskCardInput 컴포넌트 구현

#  💬 리뷰 요구사항
<!--리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.-->
- 위와 같은 상황에서 서윤님은 어떤 방식으로 textarea를 스타일링 하시나요? 궁금합니다 @yunn23 

# Etc.
<!--기타-->
