### PR TITLE
feat: 프로젝트 및 회고 리스트 페이지 ui 구현

### DIFF
--- a/src/components/DefaultButton.tsx
+++ b/src/components/DefaultButton.tsx
@@ -6,6 +6,7 @@ interface ButtonProps {
   height?: string;
   text?: string;
   fontSize?: string;
+  onClick?: () => void;
 }
 
 const MainButton = styled.button<ButtonProps>`
@@ -21,7 +22,7 @@ const MainButton = styled.button<ButtonProps>`
 
   &:hover {
     background-color: white;
-    color: black;
+    color: #88afe3;
     border: 0.1rem solid #88afe3;
   }
 `;
@@ -31,9 +32,10 @@ const DefaultButton: React.FC<ButtonProps> = ({
   height,
   text,
   fontSize,
+  onClick
 }) => {
   return (
-    <MainButton width={width} height={height} fontSize={fontSize}>
+    <MainButton width={width} height={height} fontSize={fontSize} onClick={onClick}>
       {text}
     </MainButton>
   );

--- a/src/components/RetroList.tsx
+++ b/src/components/RetroList.tsx
@@ -31,7 +31,7 @@ const RetroList = () => {
 
 const RetroListWrapper = styled.div<RetroListProps>`
     border-radius: 0.8rem;
-    border: 0.1rem solid #D4D4DB;
+    border: 0.13rem solid #D4D4DB;
     display: flex;
     flex-direction: column;
     margin: 1rem;

--- a/src/components/RetroSummary.tsx
+++ b/src/components/RetroSummary.tsx
@@ -1,0 +1,58 @@
+import styled from '@emotion/styled';
+import React from 'react';
+
+interface RetroSummaryProps {
+  content: string
+}
+
+const RetroSummary = ({ content }: RetroSummaryProps) => {
+  return (
+    <>
+      <RetroNoticeTitle>회고 요약</RetroNoticeTitle>
+      <RetroNoticeWrapper>
+        <RetroNoticeContent>{content}</RetroNoticeContent>
+      </RetroNoticeWrapper>
+    </>
+  );
+};
+
+const RetroNoticeWrapper = styled.div`
+  border-radius: 0.8rem;
+  border: 0.13rem solid #d4d4db;
+  display: flex;
+  flex-direction: column;
+  margin: 1.5rem;
+  width: 80rem;
+  position: relative;
+`;
+
+const RetroNoticeTitle = styled.div`
+  display: flex;
+  width: 8rem;
+  height: 2rem;
+  position: absolute;
+  background-color: white;
+  z-index: 1;
+  left: 30px;
+  top: 0px;
+  font-size: 1.5rem;
+  align-items: center;
+  justify-content: center;
+  color: #878993;
+  font-weight: 600;
+`;
+
+const RetroNoticeContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  padding: 1.7rem 3.2rem;
+  font-size: 1.1rem;
+  color: #505050;
+  justify-content: space-between;
+  white-space: pre-line;
+`;
+
+export default RetroSummary;

--- a/src/pages/Project.tsx
+++ b/src/pages/Project.tsx
@@ -1,9 +1,56 @@
+import styled from '@emotion/styled'
 import React from 'react'
+import DefaultButton from '../components/DefaultButton'
+import ProjectList from '../components/ProjectList'
 
 const Project = () => {
   return (
-    <div>Project</div>
+    <ProjectWrapper>
+      <Title>내 프로젝트</Title>
+      <Container>
+        <BtnContainer>
+          <DefaultButton text='프로젝트 생성하기' width='9.2rem' height='2.5rem' fontSize='1rem' />
+        </BtnContainer>
+        <ProjectList />
+      </Container>
+    </ProjectWrapper>
   )
 }
+
+const ProjectWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: calc(100vh - 13rem);
+  position: relative;
+  padding: 6rem 7.5rem;
+  box-sizing: border-box;
+`
+
+const Title = styled.div`
+  display: flex;
+  justify-content: center;
+  font-size: 1.7rem;
+  color: #484848;
+  font-weight: 600;
+  margin-bottom: 1rem;
+`
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  position: relative;
+`
+
+const BtnContainer = styled.div`
+  display: flex;
+  width: 100%
+  justify-content: flex-end;
+  align-self: flex-end;
+  margin-bottom: 0.7rem;
+`
 
 export default Project

--- a/src/pages/Project.tsx
+++ b/src/pages/Project.tsx
@@ -1,18 +1,32 @@
 import styled from '@emotion/styled'
-import React from 'react'
+import React, { useState } from 'react'
 import DefaultButton from '../components/DefaultButton'
 import ProjectList from '../components/ProjectList'
+import ProjectCreateModal from '../components/ProjectCreateModal'
 
 const Project = () => {
+
+  const [isModalOpen, setIsModalOpen] = useState(false)
+
+  const handleCreateProject = () => {
+    setIsModalOpen(true)
+    console.log('모달창 열림')
+  }
+
+  const handleModalClose = () => {
+    setIsModalOpen(false)
+  }
+
   return (
     <ProjectWrapper>
       <Title>내 프로젝트</Title>
       <Container>
         <BtnContainer>
-          <DefaultButton text='프로젝트 생성하기' width='9.2rem' height='2.5rem' fontSize='1rem' />
+          <DefaultButton text='프로젝트 생성하기' width='9.2rem' height='2.5rem' fontSize='1rem' onClick={handleCreateProject} />
         </BtnContainer>
         <ProjectList />
       </Container>
+      <ProjectCreateModal isOpen={isModalOpen} onClose={handleModalClose} />
     </ProjectWrapper>
   )
 }

--- a/src/pages/Retro.tsx
+++ b/src/pages/Retro.tsx
@@ -1,9 +1,47 @@
-import React from 'react'
+import styled from '@emotion/styled'
+import RetroList from '../components/RetroList'
+import RetroSummary from '../components/RetroSummary'
 
 const Retro = () => {
+
+  const summaryText = '회고 내용입니다.\n회고 요약 3줄 내용입니다.\n회고 요약 내용입니다.'
   return (
-    <div>Retro</div>
+    <RetroWrapper>
+      <Title>회고 리스트</Title>
+      <Container>
+        <RetroSummary content={summaryText} />
+        <RetroList />
+      </Container>
+    </RetroWrapper>
   )
 }
 
+const RetroWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: calc(100vh - 13rem);
+  position: relative;
+  padding: 6rem 7.5rem;
+  box-sizing: border-box;
+`
+
+const Title = styled.div`
+  display: flex;
+  justify-content: center;
+  font-size: 1.7rem;
+  color: #484848;
+  font-weight: 600;
+  margin-bottom: 3rem;
+`
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  position: relative;
+  line-height: 1.85rem;
+`
 export default Retro

--- a/src/pages/Yunn.tsx
+++ b/src/pages/Yunn.tsx
@@ -1,35 +1,16 @@
-import { useState } from "react";
 import MarkdownViewer from "../components/MarkdownViewer";
 import ProjectList from "../components/ProjectList";
-import styled from "@emotion/styled";
-import ProjectCreateModal from "../components/ProjectCreateModal";
 
 const Yunn = () => {
   const mdText = '# 안녕하세요'
-
-  const [isModalOpen, setIsModalOpen] = useState(false)
-
-  const handleCreateProject = () => {
-    setIsModalOpen(true)
-    console.log('모달창 열림')
-  }
-
-  const handleModalClose = () => {
-    setIsModalOpen(false)
-  }
+  
   return (
     <>
-      <Btn onClick={handleCreateProject}>버튼</Btn>
-      <ProjectCreateModal isOpen={isModalOpen} onClose={handleModalClose} />
       <ProjectList />
       <MarkdownViewer text={mdText} />
     </>
   )
 }
 
-
-const Btn = styled.div`
-
-`
 
 export default Yunn;


### PR DESCRIPTION
<!--연관된 티켓 번호를 작성하세요. 예) #111-->
# 🎟️ Related Ticket: #34 

# ✏️ Description
- 프로젝트 페이지 및 회고 리스트 페이지 ui를 구현합니다.

# 🧩 How
- 프로젝트 페이지 ui를 구현하였습니다.
- 회고 리스트 페이지 ui를 구현하였습니다.

# ⚠️ PR 참고 사항
- DefaultButton에 onClick 속성을 추가하였습니다.

# 📸 Screen Shot
- 프로젝트 페이지
  <img width="1511" alt="image" src="https://github.com/user-attachments/assets/71fa08f8-df1a-43d5-96ae-8f491c7bcf58">

- 회고 리스트 페이지
  <img width="1510" alt="image" src="https://github.com/user-attachments/assets/f7b4ebdb-0f70-40c8-8170-f5b7107e2b15">

# ✅ Todo Check
<!--todo 진행 상황을 체크하세요.-->
- [x] 프로젝트 페이지 ui 구현
- [x] 회고 리스트 페이지 ui 구현

# 💬리뷰 요구사항
<!--리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.-->


# Etc.
