### PR TITLE
feat: 회원가입 페이지 ui 구현

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,8 @@
       content="Web site created using create-react-app"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+    <!-- google material icon -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import Login from './pages/Login';
 import NavBar from './components/NavBar';
 import RetroCreate from './pages/RetroCreate';
 import RetroDetail from './pages/RetroDetail';
+import Join from './pages/Join';
 
 function App() {
 
@@ -25,11 +26,12 @@ function AppRoutes() {
   const location = useLocation()
   return (
     <>
-      {location.pathname !== '/login' && <NavBar />}
+      {location.pathname !== '/login' && location.pathname !== '/join' && <NavBar />}
       <Routes>
         <Route path='/yunn' element={<Yunn />} />
         <Route path='/min' element={<Klomachenko />} />
         <Route path='/login' element={<Login />} />
+        <Route path='/join' element={<Join />} /> 
         <Route path='/project' element={<Project />} />
         <Route path='/retro' element={<Retro />} />
         <Route path='/lastsprint' element={<LastSprint />} />

--- a/src/pages/Join.tsx
+++ b/src/pages/Join.tsx
@@ -43,7 +43,7 @@ const Join = () => {
 
 
     // // 회원가입 통신 코드
-    // if (id !== null || pw !== null) {
+    // if (nickname !== null || id !== null || pw !== null || pwCheck !== null) {
     //   await postLogin.mutateAsync({email: id, password: pw})
     // } else {
     //   alert('올바른 아이디와 비밀번호를 입력해주세요.')
@@ -107,6 +107,7 @@ const Logo = styled.div`
   font-size: 2.5rem;
   color: #54689F;
   font-weight: 700;
+  margin-bottom: 0.5rem;
 `
 
 const Title = styled.div`

--- a/src/pages/Join.tsx
+++ b/src/pages/Join.tsx
@@ -1,0 +1,199 @@
+import styled from '@emotion/styled'
+import React, { useState } from 'react'
+import { Link } from 'react-router-dom'
+
+const Join = () => {
+
+  const [nickname, setNickname] = useState('')
+  const [id, setId] = useState('')
+  const [pw, setPw] = useState('')
+  const [pwCheck, setPwCheck] = useState('')
+  const [idError, setIdError] = useState('')
+  const [isPwVisible, setIsPwVisible] = useState(false)
+  const [isPwCheckVisible, setIsPwCheckVisible] = useState(false)
+
+  const handleNicknameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setNickname(e.target.value)
+  }
+
+  const handleIdChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value.replace(/[^a-zA-Z0-9@.]/g, '');
+    setId(value)
+
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (!emailRegex.test(value)) {
+      setIdError('* 유효한 이메일 형식이 아닙니다.')
+    } else {
+      setIdError('')
+    }
+  }
+
+  const handlePwChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const filteredValue = e.target.value.replace(/[^a-zA-Z0-9!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]/g, '')
+    setPw(filteredValue)
+  }
+
+  const handlePwCheckChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const filteredValue = e.target.value.replace(/[^a-zA-Z0-9!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?]/g, '')
+    setPwCheck(filteredValue)
+  }
+
+  const handleJoinSubmit = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault()
+
+
+    // // 회원가입 통신 코드
+    // if (id !== null || pw !== null) {
+    //   await postLogin.mutateAsync({email: id, password: pw})
+    // } else {
+    //   alert('올바른 아이디와 비밀번호를 입력해주세요.')
+    // }
+    
+    // await postLogin.mutateAsync({ email: id, password: pw })
+    // navigate('/')
+  }
+
+  return (
+    <JoinWrapper>
+      <Logo>momentum</Logo>
+      <Title>회원가입</Title>
+      <Line>
+        <Label>닉네임</Label>
+        <Input type='text' placeholder='닉네임을 입력하세요' value={nickname} onChange={handleNicknameChange} />
+      </Line>
+      <IdWrapper>
+        <Line>
+          <Label>이메일</Label>
+          <Input type='text' placeholder='이메일을 입력하세요' value={id} onChange={handleIdChange} />
+        </Line>
+        {idError && <ErrorMessage>{idError}</ErrorMessage>}
+      </IdWrapper>
+      <Line>
+        <Label>비밀번호</Label>
+        <PwWrapper>
+          <Input type={isPwVisible ? 'text' : 'password'} placeholder='비밀번호를 입력하세요' required value={pw} onChange={handlePwChange} />
+          <EyeIcon className='material-symbols-outlined' onClick={() => setIsPwVisible((prev) => !prev)}>
+            {isPwVisible ? 'visibility_off' : 'visibility'}
+          </EyeIcon>
+        </PwWrapper>
+      </Line>
+      <Line>
+        <Label>비밀번호 확인</Label>
+        <PwWrapper>
+          <Input type={isPwCheckVisible ? 'text' : 'password'} placeholder='비밀번호 확인' required value={pwCheck} onChange={handlePwCheckChange} />
+          <EyeIcon className='material-symbols-outlined' onClick={() => setIsPwCheckVisible((prev) => !prev)}>
+            {isPwCheckVisible ? 'visibility_off' : 'visibility'}
+          </EyeIcon>
+        </PwWrapper>
+        
+      </Line>
+      <Button onClick={handleJoinSubmit}>회원가입</Button>
+      <Login>이미 계정이 있으신가요?  <StyledLink to={'/login'}>로그인</StyledLink></Login>
+    </JoinWrapper>
+  )
+}
+
+const JoinWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: calc(100vh - 3rem);
+  margin-top: 2rem;
+`
+
+const Logo = styled.div`
+  font-size: 2.5rem;
+  color: #54689F;
+  font-weight: 700;
+`
+
+const Title = styled.div`
+  font-size: 1.5rem;
+  padding: 2rem;
+  color: #484848;
+  font-weight: 600;
+  margin-bottom: 1rem;
+`
+
+const Line = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin: 0.5rem 0;
+`
+
+const IdWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  position: relative;
+`
+
+const Label = styled.div`
+  width: 5.5rem;
+  margin-right: 2rem;
+`
+
+const Input = styled.input`
+  width: 21rem;
+  margin-bottom: 0.5rem;
+  outline: none;
+  padding: 0.6rem 1rem;
+  box-sizing: border-box;
+`
+
+const ErrorMessage = styled.div`
+  color: #E52B2B;
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  position: relative;
+  font-size: 0.9rem;
+  left: 7rem;
+  margin-bottom: 0.7rem;
+`
+
+const PwWrapper = styled.div`
+  position: relative;
+`
+
+const EyeIcon = styled.div`
+  display: flex;
+  position: absolute;
+  right: 1rem;
+  top: 0.5rem;
+  color: #6F6F6F;
+  font-weight: 200;
+  cursor: pointer;
+`
+
+const Button = styled.button`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: #445EA2;
+  color: #ffffff;
+  width: 28.5rem;
+  border-radius: 0.5rem;
+  height: 2.5rem;
+  margin-top: 2.5rem;
+  margin-bottom: 1rem;
+  border: none;
+  font-size: 0.95rem;
+  cursor: pointer;
+`
+
+const Login = styled.div`
+  margin-top: 2.3rem;
+  color: #515151;
+  white-space: pre;
+`
+
+const StyledLink = styled(Link)`
+  text-decoration: underline;
+  display: inline;
+  color: inherit;
+`
+
+export default Join

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -20,7 +20,7 @@ const Login = () => {
   }, [])
 
   const handleIdChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const filteredValue = e.target.value.replace(/[^a-zA-Z0-9]/g, '')
+    const filteredValue = e.target.value.replace(/[^a-zA-Z0-9@.]/g, '');
     setId(filteredValue)
   }
 
@@ -37,11 +37,11 @@ const Login = () => {
   const postLogin = useMutation({
     mutationFn: postAuthLogin,
     // user_id에서 토큰 형식으로 바꾸기로 했으니 백엔드와 얘기해보고 추후 코드 변경 예정
-    // onSuccess: (data) => {
-    //   if (data.response.token) {
-    //     localStorage.setItem('token', data.response.token)
-    //   }
-    // }
+    onSuccess: (data) => {
+      if (data.response.accessToken) {
+        localStorage.setItem('token', data.response.accessToken)
+      }
+    }
   })
 
   const handleLoginSubmit = async (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -75,6 +75,7 @@ const Login = () => {
           <CheckboxLabel>아이디 저장</CheckboxLabel>
         </Options>
         <Button onClick={handleLoginSubmit}>로그인</Button>
+        <Join>아직 계정이 없으신가요?  <JoinBold>회원가입</JoinBold></Join>
     </LoginWrapper>
   )
 }
@@ -141,6 +142,17 @@ const Button = styled.button`
   border: none;
   font-size: 0.95rem;
   cursor: pointer;
+`
+
+const Join = styled.div`
+  margin-top: 2.3rem;
+  color: #515151;
+  white-space: pre;
+`
+
+const JoinBold = styled.div`
+  text-decoration: underline;
+  display: inline;
 `
 
 export default Login

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -3,6 +3,7 @@ import { useMutation } from '@tanstack/react-query'
 import React, { useEffect, useState } from 'react'
 import postAuthLogin from '../api/postAuthLogin'
 import { useNavigate } from 'react-router'
+import { Link } from 'react-router-dom'
 
 const Login = () => {
   const navigate = useNavigate()
@@ -10,6 +11,7 @@ const Login = () => {
   const [id, setId] = useState('')
   const [pw, setPw] = useState('')
   const [isCheck, setIsCheck] = useState(false)
+  const [isPwVisible, setIsPwVisible] = useState(false)
 
   useEffect(() => {
     const savedId = localStorage.getItem('savedId')
@@ -68,14 +70,19 @@ const Login = () => {
     <LoginWrapper>
         <Logo>momentum</Logo>
         <Title>로그인</Title>
-        <Input type='text' placeholder='아이디' value={id} onChange={handleIdChange} />
-        <Input type='password' placeholder='비밀번호' required value={pw} onChange={handlePwChange} />
+        <Input type='text' placeholder='이메일을 입력하세요' value={id} onChange={handleIdChange} />
+        <PwWrapper>
+          <Input type={isPwVisible ? 'text' : 'password'} placeholder='비밀번호를 입력하세요' required value={pw} onChange={handlePwChange} />
+          <EyeIcon className='material-symbols-outlined' onClick={() => setIsPwVisible((prev) => !prev)}>
+            {isPwVisible ? 'visibility_off' : 'visibility'}
+          </EyeIcon>
+        </PwWrapper>
         <Options>
           <Checkbox type='checkbox' checked={isCheck} onChange={handleCheckboxChange} />
           <CheckboxLabel>아이디 저장</CheckboxLabel>
         </Options>
         <Button onClick={handleLoginSubmit}>로그인</Button>
-        <Join>아직 계정이 없으신가요?  <JoinBold>회원가입</JoinBold></Join>
+        <Join>아직 계정이 없으신가요?  <StyledLink to={'/join'}>회원가입</StyledLink></Join>
     </LoginWrapper>
   )
 }
@@ -93,7 +100,7 @@ const Logo = styled.div`
   font-size: 2.5rem;
   color: #54689F;
   font-weight: 700;
-  margin-bottom: 2rem;
+  margin-bottom: 1rem;
 `
 
 const Title = styled.div`
@@ -101,14 +108,29 @@ const Title = styled.div`
   padding: 2rem;
   color: #484848;
   font-weight: 600;
+  margin-bottom: 1rem;
 `
 
 const Input = styled.input`
   width: 24.8rem;
-  margin-bottom: 0.5rem;
+  margin: 0.5rem 0;
   outline: none;
   padding: 0.6rem 1rem;
   box-sizing: border-box;
+`
+
+const PwWrapper = styled.div`
+  position: relative;
+`
+
+const EyeIcon = styled.div`
+  display: flex;
+  position: absolute;
+  right: 1rem;
+  top: 1rem;
+  color: #6F6F6F;
+  font-weight: 200;
+  cursor: pointer;
 `
 
 const Options = styled.div`
@@ -116,7 +138,7 @@ const Options = styled.div`
   flex-direction: row;
   justify-content: flex-start;
   width: 25rem;
-  padding-top: 0.3rem;
+  padding-top: 0.5rem;
   padding-left: 0.2rem;
 `
 const Checkbox = styled.input`
@@ -138,7 +160,8 @@ const Button = styled.button`
   width: 25rem;
   border-radius: 0.5rem;
   height: 2.5rem;
-  margin: 1rem;
+  margin-top: 2rem;
+  margin-bottom: 1rem;
   border: none;
   font-size: 0.95rem;
   cursor: pointer;
@@ -150,9 +173,10 @@ const Join = styled.div`
   white-space: pre;
 `
 
-const JoinBold = styled.div`
+const StyledLink = styled(Link)`
   text-decoration: underline;
   display: inline;
+  color: inherit;
 `
 
 export default Login


### PR DESCRIPTION
<!--연관된 티켓 번호를 작성하세요. 예) #111-->
# 🎟️ Related Ticket: #38 

# ✏️ Description
- 회원가입 페이지의 기본적인 ui를 figma에 맞게 구현하였습니다.

# 🧩 How
- 해당 페이지는 회원가입시에 사용됩니다.

# ⚠️ PR 참고 사항
- 기존 와이어프레임에는 회원가입 페이지가 없었지만, 백엔드에서 통신을 준비하는데 시간이 소요되고 백엔드에는 회원가입 기능이 존재한다고 하여 백엔드와 소통 후 남는 시간동안 회원가입 ui를 구현하였습니다.

# 📸 Screen Shot
<img width="1506" alt="image" src="https://github.com/user-attachments/assets/2a65eb03-72f3-4f25-a22d-12edc5173b39">

# ✅ Todo Check
<!--todo 진행 상황을 체크하세요.-->
- [x] 회원가입 ui 구현 완료
- [x] 로그인 비밀번호 input창에 visible 옵션 추가

# 💬리뷰 요구사항
<!--리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.-->


# Etc.
<!--기타-->
