### PR TITLE
feat: RetroPick Page 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,9 +10,9 @@ import NavBar from './components/NavBar';
 import RetroCreate from './pages/RetroCreate';
 import RetroDetail from './pages/RetroDetail';
 import Join from './pages/Join';
+import RetroPick from './pages/RetroPick';
 
 function App() {
-
   return (
     <>
       <BrowserRouter>
@@ -23,23 +23,26 @@ function App() {
 }
 
 function AppRoutes() {
-  const location = useLocation()
+  const location = useLocation();
   return (
     <>
-      {location.pathname !== '/login' && location.pathname !== '/join' && <NavBar />}
+      {location.pathname !== '/login' && location.pathname !== '/join' && (
+        <NavBar />
+      )}
       <Routes>
         <Route path='/yunn' element={<Yunn />} />
         <Route path='/min' element={<Klomachenko />} />
         <Route path='/login' element={<Login />} />
-        <Route path='/join' element={<Join />} /> 
+        <Route path='/join' element={<Join />} />
         <Route path='/project' element={<Project />} />
         <Route path='/retro' element={<Retro />} />
         <Route path='/lastsprint' element={<LastSprint />} />
         <Route path='/retrocreate' element={<RetroCreate />} />
         <Route path='/retrodetail' element={<RetroDetail />} />
+        <Route path='/retropick' element={<RetroPick />} />
       </Routes>
     </>
-  )
+  );
 }
 
 export default App;

--- a/src/components/RetroNoticeModal.tsx
+++ b/src/components/RetroNoticeModal.tsx
@@ -39,7 +39,7 @@ const RetroNoticeTitle = styled.div`
   position: absolute;
   background-color: white;
   z-index: 1;
-  left: 50px;
+  left: 200px;
   top: 0px;
   font-size: 1.75rem;
   align-items: center;

--- a/src/components/RetroPickerModal.tsx
+++ b/src/components/RetroPickerModal.tsx
@@ -4,7 +4,7 @@ import { RETRO_TYPE } from '../constants/retroType';
 
 const Container = styled.div`
   width: 20rem;
-  height: 22.5rem;
+  height: 25rem;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -17,6 +17,7 @@ const RetroTypeBox = styled.div`
   flex-direction: column;
   align-items: flex-start;
   justify-content: flex-start;
+  gap: 1rem;
 `;
 
 const RetroTypeTitle = styled.h1`
@@ -35,7 +36,7 @@ const RetroTypeSubTitle = styled.p`
 const RetroTypeContentBox = styled.div`
   box-sizing: border-box;
   width: 100%;
-  height: 9.375rem;
+  height: 13rem;
   background-color: white;
   color: #505050;
   border: 0.1875rem solid #88afe3;
@@ -48,6 +49,7 @@ const RetroTypeContentBox = styled.div`
   font-weight: 600;
   align-items: center;
   justify-content: center;
+  margin-top: 2rem;
 `;
 
 const ButtonBox = styled.div`

--- a/src/pages/RetroPick.tsx
+++ b/src/pages/RetroPick.tsx
@@ -1,0 +1,61 @@
+import styled from '@emotion/styled';
+import RetroSummary from '../components/RetroSummary';
+import RetroNoticeModal from '../components/RetroNoticeModal';
+import RetroPickerModal from '../components/RetroPickerModal';
+
+const RetroPick = () => {
+  return (
+    <RetroWrapper>
+      <Title>회고록 템플릿</Title>
+      <Container>
+        <RetroNoticeModal />
+        <RetroContainer>
+          <RetroPickerModal retroType='KPT' />
+          <RetroPickerModal retroType='CSS' />
+          <RetroPickerModal retroType='FourLs' />
+        </RetroContainer>
+      </Container>
+    </RetroWrapper>
+  );
+};
+
+export default RetroPick;
+
+const RetroWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100vh;
+  position: relative;
+  padding: 6rem 7.5rem;
+  box-sizing: border-box;
+  ::-webkit-scrollbar {
+    display: none;
+  }
+`;
+
+const Title = styled.div`
+  display: flex;
+  justify-content: center;
+  font-size: 1.7rem;
+  color: #484848;
+  font-weight: 600;
+  margin-bottom: 3rem;
+`;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  position: relative;
+  line-height: 1.85rem;
+  gap: 4rem;
+`;
+
+const RetroContainer = styled.div`
+  display: flex;
+  width: 72.125rem;
+  justify-content: space-between;
+`;


### PR DESCRIPTION
<!--연관된 티켓 번호를 작성하세요. 예) #111-->
# 🎟️ Related Ticket: #43 

# ✏️ Description
<!--설명을 작성하세요.-->
- 회고 생성시 회고 타입을 고르는 페이지의 ui를 figma에 맞게 구현하였습니다.

# 🧩 How
<!-- 구현 방법을 작성하세요.-->
- 해당 페이지는 회고 타입을 고를 때 사용됩니다.

# ⚠️ PR 참고 사항
<!-- 참고 사항을 작성하세요.-->
- retropickermodal, retronoticemodal이 화면 크기가 바뀜에 따라 해당 모달들 내부의 내용들의 위치가 달라지는 부분이 있어 해당 부분을 해결하였습니다

# 📸 Screen Shot
<!-- 이미지를 첨부하세요.-->
<img width="1840" alt="image" src="https://github.com/user-attachments/assets/b9f3ffa8-ce10-47e1-ac04-22a70524acfe">

# ✅ Todo Check
<!--todo 진행 상황을 체크하세요.-->
- [x] 회고 생성 페이지 구현

# 💬리뷰 요구사항
<!--리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.-->
- position relative, absolute를 사용하여 modal 내부 title의 위치를 강제하였습니다.

# Etc.
<!--기타-->
X