### PR TITLE
feat: kanban 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import RetroDetail from './pages/RetroDetail';
 import Join from './pages/Join';
 import RetroPick from './pages/RetroPick';
 import CompleteSprint from './pages/CompleteSprint';
+import Kanban from './pages/Kanban';
 
 function App() {
   return (
@@ -42,6 +43,7 @@ function AppRoutes() {
         <Route path='/retrodetail' element={<RetroDetail />} />
         <Route path='/retropick' element={<RetroPick />} />
         <Route path='/completesprint' element={<CompleteSprint />} />
+        <Route path='/kanban' element={<Kanban />} />
       </Routes>
     </>
   );

--- a/src/components/SprintBar.tsx
+++ b/src/components/SprintBar.tsx
@@ -1,0 +1,44 @@
+import styled from '@emotion/styled';
+import React from 'react';
+
+const SprintBar = () => {
+  return (
+    <Container>
+      <SprintBtn>스프린트 1</SprintBtn>
+      <SprintBtn>스프린트 2</SprintBtn>
+      <SprintBtn>스프린트 3</SprintBtn>
+      <SprintBtn>스프린트 4</SprintBtn>
+      <SprintBtn>스프린트 5</SprintBtn>
+    </Container>
+  );
+};
+
+export default SprintBar;
+
+const Container = styled.div`
+  width: 9rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.1875rem;
+`;
+
+const SprintBtn = styled.button`
+  width: 8.6875rem;
+  height: 3.625rem;
+  border: none;
+  background-color: #dadfee;
+  color: ${({ color }) => color || '#7A828D'};
+  font-size: 1.25rem;
+  border-radius: 0.625rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+
+  &:hover {
+    background-color: white;
+    color: #88afe3;
+    border: 0.1rem solid #88afe3;
+  }
+`;

--- a/src/pages/Kanban.tsx
+++ b/src/pages/Kanban.tsx
@@ -1,0 +1,191 @@
+import styled from '@emotion/styled';
+import TaskCard from '../components/TaskCard';
+import { FaRegClock } from 'react-icons/fa';
+import RetroSummary from '../components/RetroSummary';
+import DefaultButton from '../components/DefaultButton';
+import SprintBar from '../components/SprintBar';
+const Kanban = () => {
+  const summaryText =
+    '회고 내용입니다.\n회고 요약 3줄 내용입니다.\n회고 요약 내용입니다.';
+  return (
+    <RetroWrapper>
+      <SprintBarBox>
+        <SprintBar />
+      </SprintBarBox>
+      <Container>
+        <SummartContainer>
+          <RetroSummary content={summaryText} width='100%' />
+        </SummartContainer>
+        <DetailInfoBox>
+          <LeftInfoBox>
+            <SprintNumber>스프린트 1</SprintNumber>
+            <TimeInfoBox>
+              <FaRegClock />
+              9.30 ~ 10.13 (4일)
+            </TimeInfoBox>
+          </LeftInfoBox>
+          <DefaultButton text='스프린트 완료' />
+        </DetailInfoBox>
+        <RetroContainer>
+          <KanbanBox>
+            <KanBanListTitleBox>
+              <KanBanListTitle>할 일</KanBanListTitle>
+              <AddBtn>+</AddBtn>
+            </KanBanListTitleBox>
+            <TaskCard
+              taskContent='메인화면 컴포넌트 제작'
+              authorName='박경준'
+            />
+            <TaskCard
+              taskContent='메인화면 컴포넌트 제작'
+              authorName='박경준'
+            />
+          </KanbanBox>
+          <KanbanBox>
+            <KanBanListTitleBox>
+              <KanBanListTitle>진행중</KanBanListTitle>
+              <AddBtn>+</AddBtn>
+            </KanBanListTitleBox>
+            <TaskCard
+              taskContent='메인화면 컴포넌트 제작'
+              authorName='박경준'
+            />
+            <TaskCard
+              taskContent='메인화면 컴포넌트 제작'
+              authorName='박경준'
+            />
+            <TaskCard
+              taskContent='메인화면 컴포넌트 제작'
+              authorName='박경준'
+            />
+          </KanbanBox>
+          <KanbanBox>
+            <KanBanListTitleBox>
+              <KanBanListTitle>완료</KanBanListTitle>
+              <AddBtn>+</AddBtn>
+            </KanBanListTitleBox>
+            <TaskCard
+              taskContent='메인화면 컴포넌트 제작'
+              authorName='박경준'
+            />
+            <TaskCard
+              taskContent='메인화면 컴포넌트 제작'
+              authorName='박경준'
+            />
+          </KanbanBox>
+        </RetroContainer>
+      </Container>
+    </RetroWrapper>
+  );
+};
+
+export default Kanban;
+
+const RetroWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100vh;
+  position: relative;
+  padding: 6rem 7.5rem;
+  box-sizing: border-box;
+  ::-webkit-scrollbar {
+    display: none;
+  }
+  align-items: center;
+`;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 61rem;
+  position: relative;
+  line-height: 1.85rem;
+  gap: 2rem;
+`;
+
+const SummartContainer = styled.div`
+  box-sizing: border-box;
+  display: flex;
+  width: 61rem;
+`;
+
+const DetailInfoBox = styled.div`
+  box-sizing: border-box;
+  display: flex;
+  width: 61rem;
+  height: 2rem;
+  justify-content: space-between;
+  padding: 0 1rem;
+`;
+
+const LeftInfoBox = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+`;
+
+const SprintNumber = styled.div`
+  display: flex;
+  color: #423c3c;
+  font-size: 2.25rem;
+  font-weight: bold;
+  align-items: center;
+  justify-content: center;
+`;
+
+const TimeInfoBox = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  height: 2rem;
+  font-size: 1.125rem;
+  color: #756d6d;
+`;
+
+const RetroContainer = styled.div`
+  display: flex;
+  width: 61rem;
+  justify-content: space-between;
+`;
+
+const KanbanBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 33%;
+  align-items: center;
+`;
+
+const KanBanListTitleBox = styled.div`
+  box-sizing: border-box;
+  display: flex;
+  width: 90%;
+  font-size: 1.6rem;
+  color: #524d4d;
+  font-weight: 500;
+  margin-bottom: 0.5rem;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const KanBanListTitle = styled.div`
+  font-size: 1.6rem;
+  color: #524d4d;
+  font-weight: 500;
+`;
+
+const AddBtn = styled.div`
+  cursor: pointer;
+  color: #524d4d;
+  font-weight: 500;
+  font-size: 1.75rem;
+`;
+
+const SprintBarBox = styled.div`
+  position: fixed;
+  left: 12rem;
+`;


### PR DESCRIPTION
<!--연관된 티켓 번호를 작성하세요. 예) #111-->
# 🎟️ Related Ticket: #42 

# ✏️ Description
<!--설명을 작성하세요.-->
- figma를 참고하여 칸반보드 페이지 ui를 구현합니다.

# 🧩 How
<!-- 구현 방법을 작성하세요.-->
- 해당 페이지는 현재 진행중인 프로젝트의 스프린트를 칸반보드 카드를 이용하여 작성하고 보는 데 사용됩니다.

# ⚠️ PR 참고 사항
<!-- 참고 사항을 작성하세요.-->
- SprintBar가 fixed로 처리되어 있습니다. 화면을 줄이면 겹쳐지는 현상이 있는데, 우선 기능구현 후에 나중에 ui 수정토록 하겠습니다!

# 📸 Screen Shot
<!-- 이미지를 첨부하세요.-->
![image](https://github.com/user-attachments/assets/3bcfb641-7bc9-4700-a22c-ad4da35c569a)


# ✅ Todo Check
<!--todo 진행 상황을 체크하세요.-->
- [x] 칸반보드 페이지 구현
- [x] mock 데이터를 이용하여 스프린트 모달이 알맞게 불러와 지는지 확인

# 💬리뷰 요구사항
<!--리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.-->
- fixed 처리는 추후 수정토록 할게요!

# Etc.
<!--기타-->
- X
